### PR TITLE
Use git init/pull instead of clone to keep creds secure

### DIFF
--- a/src/git/git.go
+++ b/src/git/git.go
@@ -11,11 +11,12 @@ import (
 )
 
 // New ...
-func New(repository, dir string, output io.Writer) *Git {
+func New(repository, token, dir string, output io.Writer) *Git {
 	return &Git{
-		Repository: repository,
-		Directory:  dir,
-		Output:     output,
+		Repository:  repository,
+		AccessToken: token,
+		Directory:   dir,
+		Output:      output,
 	}
 }
 

--- a/src/git/git.go
+++ b/src/git/git.go
@@ -21,20 +21,26 @@ func New(repository, dir string, output io.Writer) *Git {
 
 // Git ...
 type Git struct {
-	Repository string
-	Directory  string
-	Output     io.Writer
+	Repository  string
+	AccessToken string
+	Directory   string
+	Output      io.Writer
+}
+
+// Auth ...
+func (g *Git) Auth() string {
+	if g.AccessToken != "" {
+		return g.AccessToken + "@"
+	}
+	return ""
 }
 
 func (g *Git) command(subcommand string, args []string) *exec.Cmd {
 	args = append([]string{subcommand}, args...)
 	cmd := exec.Command("git", args...)
+	cmd.Dir = g.Directory
 	cmd.Stdout = g.Output
 	cmd.Stderr = g.Output
-	// Only doing this for local tests to work. In concourse the output directory will already exist.
-	if subcommand != "clone" {
-		cmd.Dir = g.Directory
-	}
 	return cmd
 }
 
@@ -42,9 +48,16 @@ func (g *Git) command(subcommand string, args []string) *exec.Cmd {
 func (g *Git) CloneAndMerge(pr models.PullRequest, commit models.Commit) error {
 	var args []string
 
-	args = []string{"--branch", pr.BaseRefName, "https://github.com/" + g.Repository + ".git", g.Directory}
-	if err := g.command("clone", args).Run(); err != nil {
-		return fmt.Errorf("clone failed: %s", err)
+	if err := g.command("init", args).Run(); err != nil {
+		return fmt.Errorf("init failed: %s", err)
+	}
+	args = []string{"add", "origin", fmt.Sprintf("https://%sgithub.com/%s.git", g.Auth(), g.Repository)}
+	if err := g.command("remote", args).Run(); err != nil {
+		return fmt.Errorf("failed to add origin: %s", err)
+	}
+	args = []string{"origin", pr.BaseRefName}
+	if err := g.command("pull", args).Run(); err != nil {
+		return fmt.Errorf("pull failed: %s", err)
 	}
 	args = []string{"user.name", "concourse-ci"}
 	if err := g.command("config", args).Run(); err != nil {
@@ -62,7 +75,7 @@ func (g *Git) CloneAndMerge(pr models.PullRequest, commit models.Commit) error {
 	if err := g.command("checkout", args).Run(); err != nil {
 		return fmt.Errorf("failed to checkout new branch: %s", err)
 	}
-	args = []string{"origin", commit.OID}
+	args = []string{commit.OID}
 	if err := g.command("merge", args).Run(); err != nil {
 		return fmt.Errorf("merge failed: %s", err)
 	}

--- a/src/in/in.go
+++ b/src/in/in.go
@@ -39,7 +39,7 @@ func Run(request models.GetRequest, outputDir string) (models.GetResponse, error
 		return response, fmt.Errorf("failed to retrieve pull request: %s", err)
 	}
 
-	g := git.New(request.Source.Repository, outputDir, os.Stderr)
+	g := git.New(request.Source.Repository, request.Source.AccessToken, outputDir, os.Stderr)
 
 	// Clone the PR at the given commit
 	if err := g.CloneAndMerge(pull, commit); err != nil {


### PR DESCRIPTION
Doing this in preparation for `access_token` passed to the pull command. Don't write them to disk:
https://blog.github.com/2012-09-21-easier-builds-and-deployments-using-git-over-https-and-oauth/