### PR TITLE
Feature/Handle of out-of-order commits

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -28,6 +28,24 @@ var (
 			Tip:               createTestCommit(4, false),
 		},
 	}
+	testPreviousPullRequests = []*resource.PullRequest{
+		{
+			PullRequestObject: createTestPR(1),
+			Tip:               createTestCommit(3, true),
+		},
+		{
+			PullRequestObject: createTestPR(2),
+			Tip:               createTestCommit(4, false),
+		},
+		{
+			PullRequestObject: createTestPR(3),
+			Tip:               createTestCommit(2, false),
+		},
+		{
+			PullRequestObject: createTestPR(4),
+			Tip:               createTestCommit(6, false),
+		},
+	}
 )
 
 func TestCheck(t *testing.T) {
@@ -49,7 +67,7 @@ func TestCheck(t *testing.T) {
 			pullRequests: testPullRequests,
 			files:        [][]string{},
 			expected: resource.CheckResponse{
-				resource.NewVersion(testPullRequests[1]),
+				resource.NewVersion(testPullRequests[1], resource.GenerateVersion(testPullRequests[1:])),
 			},
 		},
 
@@ -59,11 +77,11 @@ func TestCheck(t *testing.T) {
 				Repository:  "itsdalmo/test-repository",
 				AccessToken: "oauthtoken",
 			},
-			version:      resource.NewVersion(testPullRequests[1]),
-			pullRequests: testPullRequests,
+			version:      resource.NewVersion(testPreviousPullRequests[1], resource.GenerateVersion(testPreviousPullRequests)),
+			pullRequests: testPreviousPullRequests,
 			files:        [][]string{},
 			expected: resource.CheckResponse{
-				resource.NewVersion(testPullRequests[1]),
+				resource.NewVersion(testPreviousPullRequests[1], resource.GenerateVersion(testPreviousPullRequests)),
 			},
 		},
 
@@ -73,23 +91,23 @@ func TestCheck(t *testing.T) {
 				Repository:  "itsdalmo/test-repository",
 				AccessToken: "oauthtoken",
 			},
-			version:      resource.NewVersion(testPullRequests[3]),
+			version:      resource.NewVersion(testPreviousPullRequests[3], resource.GenerateVersion(testPreviousPullRequests)),
 			pullRequests: testPullRequests,
 			files:        [][]string{},
 			expected: resource.CheckResponse{
-				resource.NewVersion(testPullRequests[2]),
-				resource.NewVersion(testPullRequests[1]),
+				resource.NewVersion(testPullRequests[3], resource.GenerateVersion(testPullRequests[1:4])),
+				resource.NewVersion(testPullRequests[1], resource.GenerateVersion(testPullRequests[1:4])),
 			},
 		},
 
 		{
-			description: "check will only return versions that match the specified paths",
+			description: "check will only return versions that match the specified paths and are newer",
 			source: resource.Source{
 				Repository:  "itsdalmo/test-repository",
 				AccessToken: "oauthtoken",
 				Paths:       []string{"terraform/*/*.tf", "terraform/*/*/*.tf"},
 			},
-			version:      resource.NewVersion(testPullRequests[3]),
+			version:      resource.NewVersion(testPreviousPullRequests[3], resource.GenerateVersion(testPreviousPullRequests)),
 			pullRequests: testPullRequests,
 			files: [][]string{
 				{"README.md", "travis.yml"},
@@ -97,7 +115,7 @@ func TestCheck(t *testing.T) {
 				{"terraform/modules/variables.tf", "travis.yml"},
 			},
 			expected: resource.CheckResponse{
-				resource.NewVersion(testPullRequests[2]),
+				resource.NewVersion(testPullRequests[3], resource.GenerateVersion(testPullRequests[2:])),
 			},
 		},
 
@@ -108,7 +126,7 @@ func TestCheck(t *testing.T) {
 				AccessToken: "oauthtoken",
 				IgnorePaths: []string{"*.md", "*.yml"},
 			},
-			version:      resource.NewVersion(testPullRequests[3]),
+			version:      resource.NewVersion(testPullRequests[3], resource.GenerateVersion(testPullRequests[3:])),
 			pullRequests: testPullRequests,
 			files: [][]string{
 				{"README.md", "travis.yml"},
@@ -116,7 +134,7 @@ func TestCheck(t *testing.T) {
 				{"terraform/modules/variables.tf", "travis.yml"},
 			},
 			expected: resource.CheckResponse{
-				resource.NewVersion(testPullRequests[2]),
+				resource.NewVersion(testPullRequests[2], resource.GenerateVersion(testPullRequests[2:])),
 			},
 		},
 		{
@@ -126,10 +144,10 @@ func TestCheck(t *testing.T) {
 				AccessToken:   "oauthtoken",
 				DisableCISkip: "true",
 			},
-			version:      resource.NewVersion(testPullRequests[1]),
+			version:      resource.NewVersion(testPullRequests[1], resource.GenerateVersion(testPullRequests[1:])),
 			pullRequests: testPullRequests,
 			expected: resource.CheckResponse{
-				resource.NewVersion(testPullRequests[0]),
+				resource.NewVersion(testPullRequests[0], resource.GenerateVersion(testPullRequests)),
 			},
 		},
 	}
@@ -147,6 +165,7 @@ func TestCheck(t *testing.T) {
 				gomock.InOrder(
 					github.EXPECT().ListModifiedFiles(gomock.Any()).Times(1).Return(tc.files[0], nil),
 					github.EXPECT().ListModifiedFiles(gomock.Any()).Times(1).Return(tc.files[1], nil),
+					github.EXPECT().ListModifiedFiles(gomock.Any()).Times(1).Return(tc.files[2], nil),
 				)
 			}
 

--- a/in_test.go
+++ b/in_test.go
@@ -42,7 +42,7 @@ func TestGet(t *testing.T) {
 			parameters:     resource.GetParameters{},
 			pullRequest:    createTestPR(1),
 			commit:         createTestCommit(1, false),
-			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
+			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","alreadyseen":""}`,
 			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_sha","value":"oid1"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"}]`,
 		},
 	}

--- a/models.go
+++ b/models.go
@@ -49,19 +49,27 @@ type MetadataField struct {
 	Value string `json:"value"`
 }
 
+// AlreadySeenVersion Interesting values compressed into data blob stored in Version.AlreadySeen
+type AlreadySeenVersion struct {
+	PR            string
+	committedDate time.Time
+}
+
 // Version communicated with Concourse. ID is the Github Global ID.
 type Version struct {
 	PR            string    `json:"pr"`
 	Commit        string    `json:"commit"`
 	CommittedDate time.Time `json:"committed,omitempty"`
+	AlreadySeen   string    `json:"alreadyseen"`
 }
 
 // NewVersion constructs a new Version.
-func NewVersion(p *PullRequest) Version {
+func NewVersion(p *PullRequest, alreadySeen string) Version {
 	return Version{
 		PR:            p.ID,
 		Commit:        p.Tip.ID,
 		CommittedDate: p.Tip.CommittedDate.Time,
+		AlreadySeen:   alreadySeen,
 	}
 }
 


### PR DESCRIPTION
Enable handling of out-of-order commits

Playing around with a strategy to resolve #26 

Keep track of "already-seen" commits, as pairs of PR#:CommittedDate
And PRs with new commits (as compared to previously-seen tip commit date) will be returned as new versions

Potential improvements:
- [ ] compress `alreadyseen` via gzip or equivalent
- [ ] more explicit test cases